### PR TITLE
v1.0.12

### DIFF
--- a/paypal-framework.php
+++ b/paypal-framework.php
@@ -480,6 +480,8 @@ class wpPayPalFramework
 	 */
 	public function hashCall( $args ) {
 		$params = array(
+			'headers' => array( 'Host' => 'www.paypal.com' ),
+			'httpversion' => '1.1',
 			'body'		=> $this->_prepRequest($args),
 			'sslverify' => apply_filters( 'paypal_framework_sslverify', false ),
 			'timeout' 	=> 30,
@@ -588,6 +590,8 @@ class wpPayPalFramework
 
 		// We need to send the message back to PayPal just as we received it
 		$params = array(
+			'headers' => array( 'Host' => 'www.paypal.com' ),
+			'httpversion' => '1.1',
 			'body' => $_POST,
 			'sslverify' => apply_filters( 'paypal_framework_sslverify', false ),
 			'timeout' 	=> 30,

--- a/paypal-framework.php
+++ b/paypal-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: PayPal Framework
  * Plugin URI: http://bluedogwebservices.com/wordpress-plugin/paypal-framework/
  * Description: PayPal integration framework and admin interface as well as IPN listener.  Requires PHP5.
- * Version: 1.0.11
+ * Version: 1.0.12
  * Author: Aaron D. Campbell
  * Author URI: http://bluedogwebservices.com/
  * License: GPL
@@ -480,7 +480,6 @@ class wpPayPalFramework
 	 */
 	public function hashCall( $args ) {
 		$params = array(
-			'headers' => array( 'Host' => 'www.paypal.com' ),
 			'httpversion' => '1.1',
 			'body'		=> $this->_prepRequest($args),
 			'sslverify' => apply_filters( 'paypal_framework_sslverify', false ),
@@ -590,7 +589,6 @@ class wpPayPalFramework
 
 		// We need to send the message back to PayPal just as we received it
 		$params = array(
-			'headers' => array( 'Host' => 'www.paypal.com' ),
 			'httpversion' => '1.1',
 			'body' => $_POST,
 			'sslverify' => apply_filters( 'paypal_framework_sslverify', false ),

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: aaroncampbell
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal%40xavisys%2ecom&item_name=PayPal%20Framework&no_shipping=0&no_note=1&tax=0&currency_code=USD&lc=US&bn=PP%2dDonationsBF&charset=UTF%2d8
 Tags: paypal
 Requires at least: 2.8
-Tested up to: 3.1
-Stable tag: 1.0.11
+Tested up to: 4.4.2
+Stable tag: 1.0.12
 
 PayPal integration framework and admin interface as well as IPN listener.
 
@@ -97,6 +97,9 @@ add_filter( 'paypal_framework_sslverify', '__return_true' );
 </code>
 
 == Changelog ==
+
+= 1.0.12 =
+* Add host and httpversion 1.1 to wp_remote_get(). Now required by PayPal Sandbox to support TLS 1.2. - props @cferdinandi
 
 = 1.0.11 =
 * Don't verify SSL on validation calls - too many people with out of date CAs

--- a/readme.txt
+++ b/readme.txt
@@ -99,7 +99,7 @@ add_filter( 'paypal_framework_sslverify', '__return_true' );
 == Changelog ==
 
 = 1.0.12 =
-* Add host and httpversion 1.1 to wp_remote_get(). Now required by PayPal Sandbox to support TLS 1.2. - props @cferdinandi
+* Add httpversion 1.1 to wp_remote_get(). Now required by PayPal Sandbox to support TLS 1.2. - props @cferdinandi
 
 = 1.0.11 =
 * Don't verify SSL on validation calls - too many people with out of date CAs


### PR DESCRIPTION
Add `host` and `httpversion` 1.1 to `wp_remote_get()`. Now required by PayPal Sandbox to support TLS 1.2. Sandbox fails without it.
